### PR TITLE
fix and call to a member function delay() on int in Laravel 9.X

### DIFF
--- a/src/PendingCertificate.php
+++ b/src/PendingCertificate.php
@@ -117,8 +117,8 @@ class PendingCertificate
                 $this->retryList
             ),
         ], $this->chain))
-            ->dispatch($email, $this->tries, $this->retryAfter, $this->retryList)
-            ->delay($this->delay);
+            ->delay($this->delay)
+            ->dispatch($email, $this->tries, $this->retryAfter, $this->retryList);
 
         return $certificate;
     }


### PR DESCRIPTION
Error:
```
  Call to a member function delay() on int

  at vendor/daanra/laravel-lets-encrypt/src/PendingCertificate.php:116
    112▕                 $this->retryList
    113▕             ),
    114▕ 	], $this->chain))
    115▕ 	 ->dispatch($email, $this->tries, $this->retryAfter, $this->retryList)
  ➜ 116▕  ->delay($this->delay);
    117▕
    118▕         return $certificate;
    119▕     }
    120▕
```

How to reproduce?
Run code:
```
LetsEncrypt::certificate($domain)
            ->delay(5)
            ->retryAfter(4)
            ->setTries(4)
            ->setRetryList([1, 5, 10])
            ->renew();
```

Laravel Framework 9.44.0

