### PR TITLE
Fix default value for subject_alternative_names

### DIFF
--- a/database/migrations/add_lets_encrypt_certificates_subject_alternative_names.php.stub
+++ b/database/migrations/add_lets_encrypt_certificates_subject_alternative_names.php.stub
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Facades\Schema;
 
 class AddLetsEncryptCertificatesSubjectAlternativeNames extends Migration
@@ -9,7 +10,7 @@ class AddLetsEncryptCertificatesSubjectAlternativeNames extends Migration
     public function up()
     {
         Schema::table('lets_encrypt_certificates', function (Blueprint $table) {
-            $table->json('subject_alternative_names')->default('[]')->after('domain');
+            $table->json('subject_alternative_names')->default(new Expression('(JSON_ARRAY())'))->after('domain');
         });
     }
 


### PR DESCRIPTION
The 'subject_alternative_names' column in the migration had a default value of an empty JSON array as a string, which caused an error when running the migration. This PR fixes the error by updating the default value to use an Expression as documented [here.](https://laravel.com/docs/9.x/migrations#default-expressions)

> Using an Expression instance will prevent Laravel from wrapping the value in quotes and allow you to use database 
> specific functions. One situation where this is particularly useful is when you need to assign default values to JSON 
> columns.

Fixes #29 