### PR TITLE
fix: add a second param to StoreCertificateFailed dispatch from StoreCertificate::failed

### DIFF
--- a/src/Jobs/StoreCertificate.php
+++ b/src/Jobs/StoreCertificate.php
@@ -18,6 +18,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
+use Throwable;
 
 class StoreCertificate implements ShouldQueue
 {
@@ -103,8 +104,8 @@ class StoreCertificate implements ShouldQueue
      *
      * @return void
      */
-    public function failed(\Throwable $exception)
+    public function failed(Throwable $exception)
     {
-        event(new StoreCertificateFailed($exception));
+        event(new StoreCertificateFailed($exception, $this->dbCertificate));
     }
 }


### PR DESCRIPTION
I've noticed that the `StoreCertificate::failed` method fails for me, because it's trying to dispatch `StoreCertificateFailed` event without the required second param of the certificate model. I've looked at that method in other Job classes, but it seems to be the only one where this bug exists.